### PR TITLE
Automate template substitution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux GOA
 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot as runner
+LABEL org.opencontainers.image.source=https://github.com/rode/new-collector-template
 WORKDIR /
 COPY --from=builder /workspace/collector .
 COPY --from=builder /bin/grpc_health_probe .

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ Boilerplate for creating new collectors.
 
 ## Usage
 
-This template can be automatically reconfigured, given the name of the new collector:
-
 1. Hit the "Use this template" button to create a new repository from the template.
-1. Run `./template.sh collector-foo-bar`
-1. Make any needed modifications under the `proto` directory for the collector's API
+1. Run `./template.sh collector-foo-bar`.
+1. Make any needed modifications under the `proto` directory for the collector's API.
 1. Pick an unallocated port and update the `config` package to replace the default for `--port`.
     - The `config` tests will need to be updated as well
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ Boilerplate for creating new collectors.
 
 ## Usage
 
+This template can be automatically reconfigured, given the name of the new collector:
+
 1. Hit the "Use this template" button to create a new repository from the template.
-1. Update the go mod file with the new root module: `go mod edit -module "github.com/rode/$MY_COLLECTOR"`.
-1. Find and replace any usages of the following with your collector name:
-    1. new-collector-template
-    1. newCollectorTemplate 
-    1. new_collector_template
-1. Delete or modify the proto files under `proto/v1alpha1`.
-   - Remove any generated code under `proto`
-1. Run `make generate` to update the generated server code. 
-1. Update the `server` package to implement the new gRPC server interface.
-1. Update `main.go` to reference the new server and handler code
+1. Run `./template.sh collector-foo-bar`
+1. Make any needed modifications under the `proto` directory for the collector's API
 1. Pick an unallocated port and update the `config` package to replace the default for `--port`.
     - The `config` tests will need to be updated as well
 

--- a/template.sh
+++ b/template.sh
@@ -89,7 +89,7 @@ rm "$projectName"
 info "Updating README"
 echo "# $projectName" > README.md
 
-info "Build Docker image"
+info "Building Docker image"
 docker build -t "$projectName" .
 
 info "Done, deleting this script"

--- a/template.sh
+++ b/template.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RED=$(tput setaf 1)
+YELLOW=$(tput setaf 3)
+GREEN=$(tput setaf 2)
+DEFAULT=$(tput sgr0)
+
+function to_snake_case() {
+    echo "${1//-/_}"
+}
+
+function to_camel_case() {
+    echo "$1" | awk -F - '{printf "%s", $1; for(i=2; i<=NF; i++) printf "%s", toupper(substr($i,1,1)) substr($i,2); print"";}'
+}
+
+function to_pascal_case() {
+    camelCase=$(to_camel_case "$1")
+    echo "${camelCase}" | awk '{print toupper(substr($0,0,1))substr($0,2)}'
+}
+
+function warn() {
+  printf "%s\n" "${RED}$1${DEFAULT}"
+}
+
+function attention() {
+  printf "%s\n" "${YELLOW}$1${DEFAULT}"
+}
+
+function info() {
+  printf "%s\n" "${GREEN}$1${DEFAULT}"
+}
+
+function replace() {
+  attention "Replacing instances of '$1' with '$2'"
+  find .  \
+    \( -name "*.go" -o -name "*.yml" -o -name "*.proto" -o -name "Dockerfile" -o -name "Makefile" -o -name "go.mod" \) \
+    -exec sed -i '' 's/'"$1"'/'"$2"'/g' {} \;
+}
+
+templateProjectName="new-collector-template"
+projectName="${1-}"
+
+if [ -z "$projectName" ]; then
+  warn "Must supply a hyphenated project name"
+  warn "ex: ./template.sh my-collector-name"
+  exit 1
+fi
+
+info "Updating template to use name '$projectName'"
+
+warn "Removing generated protobuf code"
+rm -f proto/v1alpha1/*.pb.go
+rm -f proto/v1alpha1/*.pb.*.go
+
+warn "Renaming protobuf file"
+mv "proto/v1alpha1/${templateProjectName}.proto" "proto/v1alpha1/${projectName}.proto"
+
+replace "$templateProjectName" "$projectName"
+
+templateProjectNameCamelCase=$(to_camel_case "$templateProjectName")
+projectNameCamelCase=$(to_camel_case "$projectName")
+replace "$templateProjectNameCamelCase" "$projectNameCamelCase"
+
+templateProjectNamePascalCase=$(to_pascal_case "$templateProjectName")
+projectNamePascalCase=$(to_pascal_case "$projectName")
+replace "$templateProjectNamePascalCase" "$projectNamePascalCase"
+
+templateProjectNameSnakeCase=$(to_snake_case "$templateProjectName")
+projectNameSnakeCase=$(to_snake_case "$projectName")
+replace "$templateProjectNameSnakeCase" "$projectNameSnakeCase"
+
+info "Regenerating protos"
+make generate
+
+info "Formatting"
+make fmt
+
+info "Building binary"
+go build -v .
+
+info "Running tests"
+make test
+
+info "Cleaning up binary"
+rm "$projectName"
+
+info "Updating README"
+echo "# $projectName" > README.md
+
+info "Build Docker image"
+docker build -t "$projectName" .
+
+info "Done, deleting this script"
+rm -- "$0"


### PR DESCRIPTION
Closes #9

This PR adds a script to automatically replace the template name with the new collector's name. It updates any source code references, regenerates the protos, and tries to check the result by compiling the Go code, running unit tests, and building the Docker image. 
Finally, it cleans itself up on success. 

Here's a sample run:
```shell
$ ./template.sh collector-image-scanner
Updating template to use name 'collector-image-scanner'
Removing generated protobuf code
Renaming protobuf file
Replacing instances of 'new-collector-template' with 'collector-image-scanner'
Replacing instances of 'newCollectorTemplate' with 'collectorImageScanner'
Replacing instances of 'NewCollectorTemplate' with 'CollectorImageScanner'
Replacing instances of 'new_collector_template' with 'collector_image_scanner'
Regenerating protos
# removed proto build script output
Formatting
Building binary
Running tests
# removed test output
Cleaning up binary
Updating README
Build Docker image
# removed docker build output
Done, deleting this script
```


Also adds a source label to the Dockerfile. Closes #10 
